### PR TITLE
fix(comments): ensure auto-scroll works after sending large messages

### DIFF
--- a/src/data/changelogs.json
+++ b/src/data/changelogs.json
@@ -8,11 +8,17 @@
         "Respuestas rápidas con comando '/' en el textarea",
         "Soporte para emojis con comando ':' y lista permitida",
         "Menú de comandos más ancho y alto, muestra más texto y mantiene foco al insertar",
-        "Buscador dentro del menú con filtrado en vivo",
+        "Buscador dentro del menú de respuestas rapidas con filtrado en vivo",
         "Navegación con teclado más robusta (↑/↓ y Ctrl/Alt/Meta + J/K)",
-        "Accesibilidad y pistas de uso en el footer del menú"
+        "Accesibilidad y pistas de uso en el footer del menú",
+        "Corrección del scroll automático al enviar mensajes grandes"
       ],
       "changes": [
+        {
+          "type": "fixed",
+          "title": "Scroll en conversaciones",
+          "details": "El scroll ahora baja completamente al final después de enviar mensajes grandes, asegurando que el último mensaje sea visible."
+        },
         {
           "type": "added",
           "title": "Comando '/' para respuestas rápidas",

--- a/src/views/home/partials/CommentsV2.js
+++ b/src/views/home/partials/CommentsV2.js
@@ -465,9 +465,11 @@ const CommentsV2 = ({ folio, fullFolio, onCall, setOnCall, setRefresh, sidCall, 
             }, 0);
             setShowResponseTo(null);
             setMessageToResponse(null);
-            if (listFolios.currentBox) {
-                listFolios.currentBox.scrollTop = listFolios.currentBox.scrollHeight;
-            }
+            setTimeout(() => {
+                if (listFolios.currentBox) {
+                    listFolios.currentBox.scrollTop = listFolios.currentBox.scrollHeight;
+                }
+            }, 0);
             console.log('Message sent successfully, clearing draft for folio:', folio._id);
             if (folio && folio._id) {
                 clearDraftForFolio(folio._id);


### PR DESCRIPTION
Wrap scroll adjustment in setTimeout to ensure it executes after DOM updates Update version in changelogs.json to reflect the fix