### PR TITLE
feat: display label field instead of name in MTM list when available

### DIFF
--- a/src/views/home/partials/Mtm.js
+++ b/src/views/home/partials/Mtm.js
@@ -224,7 +224,7 @@ const Mtm = ({ mtm, person, setRefresh, folio }) => {
                             onClick={() => getMtm(item._id)}
                             title={item.previewtxt}
                         >
-                            {item.name}
+                            {item.label ? item.label : item.name}
                         </li>
                     ))}
                 </ul>


### PR DESCRIPTION
- Updated MTM list item display to show label field if present, falling back to name field
- Enhances readability by showing more descriptive labels when configured
- Maintains backwards compatibility by using name field when label is not set